### PR TITLE
Revert "feat: Add udev rule for STM32F042"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,19 +239,6 @@ if (NOT "${WASM}")
             DESTINATION share/applications)
 endif ()
 
-if (LINUX)
-    set(PACKAGE_UDEV_RULE "extras/udev/71-zero-elabviewer-community.rules")
-
-    option(INSTALL_UDEV_RULES "Install udev rules to the system" OFF)
-    set(UDEV_RULES_INSTALL_DIR "/lib/udev/rules.d/"
-        CACHE STRING "Path where to install the udev rules file")
-
-    if (INSTALL_UDEV_RULES)
-        install(FILES ${PACKAGE_UDEV_RULE}
-                DESTINATION ${UDEV_RULES_INSTALL_DIR})
-    endif ()
-endif ()
-
 # =============================================================================
 # Packages
 # =============================================================================
@@ -285,7 +272,6 @@ if ("${DEV_MODE}")
             ${PACKAGE_NAME}_${PACKAGE_VERSION}-${PACKAGE_RELEASE}.dsc
             extras/packaging/deb/dsc.in
             extras/packaging/deb/debian
-            ${PACKAGE_UDEV_RULE}
             ${PACKAGE_NAME}_${PACKAGE_VERSION}-${PACKAGE_RELEASE}.debian.tar.xz)
     # Creates bunch of files in ${CMAKE_BINARY_DIR}/target/pkg that you can just pass to
     # Open Build Service and it will build all packaging.

--- a/cmake/PackageTools.cmake
+++ b/cmake/PackageTools.cmake
@@ -55,17 +55,13 @@ macro(package_config_file target_name config_file_name template)
 			DEPENDS ${config_file_name})
 endmacro()
 
-macro(package_debian_quilt target_name config_file_name template debian_dir udev_rule output_archive)
+macro(package_debian_quilt target_name config_file_name template debian_dir output_archive)
 	file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/debian)
 	# The @ONLY option disable replacement of ${} which may be used by shell as well.
 	configure_file(${debian_dir}/control.in ${CMAKE_BINARY_DIR}/debian/control @ONLY)
 	file(COPY ${CMAKE_BINARY_DIR}/debian/control DESTINATION ${CMAKE_BINARY_DIR}/debian
 			FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
 	file(COPY ${debian_dir}/compat
-			DESTINATION ${CMAKE_BINARY_DIR}/debian
-			FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
-	configure_file(${udev_rule} ${CMAKE_BINARY_DIR}/debian/${PACKAGE_NAME}.udev COPYONLY)
-	file(COPY ${CMAKE_BINARY_DIR}/debian/${PACKAGE_NAME}.udev
 			DESTINATION ${CMAKE_BINARY_DIR}/debian
 			FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
 	file(COPY ${debian_dir}/rules

--- a/extras/packaging/arch/PKGBUILD.in
+++ b/extras/packaging/arch/PKGBUILD.in
@@ -16,11 +16,7 @@ prepare() {
 	cd "$srcdir/@PACKAGE_TOPLEVEL_DIR@"
 	mkdir build
 	cd build
-	cmake .. \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DINSTALL_UDEV_RULES=ON \
-		-DUDEV_RULES_INSTALL_DIR="${pkgdir}/usr/lib/udev/rules.d"
+	cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
 }
 
 build() {

--- a/extras/packaging/deb/debian/rules
+++ b/extras/packaging/deb/debian/rules
@@ -11,6 +11,3 @@ export QT_SELECT := qt5
 
 %:
 	dh $@ --buildsystem=cmake
-
-override_dh_installudev:
-	dh_installudev --priority=71

--- a/extras/packaging/rpm/spec.in
+++ b/extras/packaging/rpm/spec.in
@@ -67,7 +67,7 @@ BuildRequires:  update-desktop-files
 
 %build
 %if 0%{?suse_version}
-%cmake -DCMAKE_CXX_FLAGS="-Wno-error" -DCMAKE_C_FLAGS="-Wno-error" -DINSTALL_UDEV_RULES=ON -DUDEV_RULES_INSTALL_DIR=%{buildroot}%{_udevrulesdir}
+%cmake -DCMAKE_CXX_FLAGS="-Wno-error" -DCMAKE_C_FLAGS="-Wno-error"
 %else
 %cmake
 %endif

--- a/extras/udev/71-zero-elabviewer-community.rules
+++ b/extras/udev/71-zero-elabviewer-community.rules
@@ -1,2 +1,0 @@
-# F0-Lab - STM32F042F6P6 - VCP mode
-SUBSYSTEM=="tty", ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", TAG+="uaccess", ENV{ID_MM_DEVICE_MANUAL_SCAN_ONLY}="1"


### PR DESCRIPTION
This reverts commit d0aaa6c3aafc876224c281055ef1ed2e4c88d08e.

See the rationale in https://github.com/adamberlinger/zero_elabviewer/pull/8/commits/3464a23e872c995bc06a989c6dd2f33cf02bbab0 . Additionally, the error message explanation might be enough even for beginners.