### PR TITLE
Partially revert "feat: Add udev rule for STM32F042"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,6 @@ if ("${DEV_MODE}")
             ${PACKAGE_NAME}_${PACKAGE_VERSION}-${PACKAGE_RELEASE}.dsc
             extras/packaging/deb/dsc.in
             extras/packaging/deb/debian
-            ${PACKAGE_UDEV_RULE}
             ${PACKAGE_NAME}_${PACKAGE_VERSION}-${PACKAGE_RELEASE}.debian.tar.xz)
     # Creates bunch of files in ${CMAKE_BINARY_DIR}/target/pkg that you can just pass to
     # Open Build Service and it will build all packaging.

--- a/cmake/PackageTools.cmake
+++ b/cmake/PackageTools.cmake
@@ -55,17 +55,13 @@ macro(package_config_file target_name config_file_name template)
 			DEPENDS ${config_file_name})
 endmacro()
 
-macro(package_debian_quilt target_name config_file_name template debian_dir udev_rule output_archive)
+macro(package_debian_quilt target_name config_file_name template debian_dir output_archive)
 	file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/debian)
 	# The @ONLY option disable replacement of ${} which may be used by shell as well.
 	configure_file(${debian_dir}/control.in ${CMAKE_BINARY_DIR}/debian/control @ONLY)
 	file(COPY ${CMAKE_BINARY_DIR}/debian/control DESTINATION ${CMAKE_BINARY_DIR}/debian
 			FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
 	file(COPY ${debian_dir}/compat
-			DESTINATION ${CMAKE_BINARY_DIR}/debian
-			FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
-	configure_file(${udev_rule} ${CMAKE_BINARY_DIR}/debian/${PACKAGE_NAME}.udev COPYONLY)
-	file(COPY ${CMAKE_BINARY_DIR}/debian/${PACKAGE_NAME}.udev
 			DESTINATION ${CMAKE_BINARY_DIR}/debian
 			FILE_PERMISSIONS OWNER_READ GROUP_READ WORLD_READ)
 	file(COPY ${debian_dir}/rules

--- a/extras/packaging/arch/PKGBUILD.in
+++ b/extras/packaging/arch/PKGBUILD.in
@@ -16,11 +16,7 @@ prepare() {
 	cd "$srcdir/@PACKAGE_TOPLEVEL_DIR@"
 	mkdir build
 	cd build
-	cmake .. \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DINSTALL_UDEV_RULES=ON \
-		-DUDEV_RULES_INSTALL_DIR="${pkgdir}/usr/lib/udev/rules.d"
+	cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr
 }
 
 build() {

--- a/extras/packaging/deb/debian/rules
+++ b/extras/packaging/deb/debian/rules
@@ -11,6 +11,3 @@ export QT_SELECT := qt5
 
 %:
 	dh $@ --buildsystem=cmake
-
-override_dh_installudev:
-	dh_installudev --priority=71

--- a/extras/packaging/rpm/spec.in
+++ b/extras/packaging/rpm/spec.in
@@ -67,7 +67,7 @@ BuildRequires:  update-desktop-files
 
 %build
 %if 0%{?suse_version}
-%cmake -DCMAKE_CXX_FLAGS="-Wno-error" -DCMAKE_C_FLAGS="-Wno-error" -DINSTALL_UDEV_RULES=ON -DUDEV_RULES_INSTALL_DIR=%{buildroot}%{_udevrulesdir}
+%cmake -DCMAKE_CXX_FLAGS="-Wno-error" -DCMAKE_C_FLAGS="-Wno-error"
 %else
 %cmake
 %endif


### PR DESCRIPTION
This partially reverts commit d0aaa6c3aafc876224c281055ef1ed2e4c88d08e.

This is an alternative to https://github.com/cvut-fel-sdi/zero_elabviewer_community/pull/20 that keeps the udev rule, but removes it from packages.